### PR TITLE
Update dolittle build dependencies to specific basic version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,3 @@
 {
-    "presets": [
-      "./node_modules/@dolittle/build/.babelrc.js"
-    ]
-  }
+    "extends": "@dolittle/build/.babelrc"
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
     "presets": [
-      "./node_modules/dolittle.javascript.build/.babelrc.js"
+      "./node_modules/@dolittle/build/.babelrc.js"
     ]
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,1 @@
+require('@dolittle/build/dist/gulp/setup')(exports);

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "transpile": "rm -rf dist && PACKAGE_DISTRIBUTION=true npx babel Source --ignore node_modules,**/for_* -d dist",
-    "prepublish": "yarn run transpile"
+    "build": "gulp build",
+    "prepublish": "yarn build"
   },
   "devDependencies": {
-    "@dolittle/build.aurelia": "1.1.1"
+    "@dolittle/build.aurelia": "3.2.2"
   },
   "dependencies": {
     "@dolittle/commands": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "build": "gulp build",
     "prepublish": "yarn build"
   },
+  "files":[
+    "dist"
+  ],
   "devDependencies": {
     "@dolittle/build.aurelia": "3.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dolittle/aurelia",
   "author": "",
   "license": "ISC",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "",
   "main": "dist/index.js",
   "scripts": {
@@ -10,13 +10,12 @@
     "prepublish": "yarn run transpile"
   },
   "devDependencies": {
-    "dolittle.javascript.build": "https://github.com/dolittle/JavaScript.Build.git",
-    "dolittle.javascript.build.aurelia": "https://github.com/dolittle-interaction/JavaScript.Build.Aurelia.git"
+    "@dolittle/build.aurelia": "1.1.1"
   },
   "dependencies": {
-    "aurelia-bootstrapper": "^2.2.0",
     "@dolittle/commands": "^1.0.6",
     "@dolittle/core": "^1.0.2",
-    "@dolittle/queries": "^1.0.7"
+    "@dolittle/queries": "^1.0.7",
+    "aurelia-bootstrapper": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,17 @@
   "license": "ISC",
   "version": "1.0.16",
   "description": "",
-  "main": "dist/index.js",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esmodule/index.js",
+  "jspm": {
+    "registry":"npm",
+    "jspmPackage": true,
+    "format": "esm",
+    "main": "index",
+    "directories": {
+        "dist": "dist/systemjs"
+    }
+  },
   "scripts": {
     "build": "gulp build",
     "prepublish": "yarn build"

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,2 +1,2 @@
-const wallaby = require('dolittle.javascript.build.aurelia/wallaby')
-module.exports = wallaby('Source');
+const wallaby = require('@dolittle/build/dist/wallaby/node')
+module.exports = wallaby('.', (config) => {});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-const config = require('dolittle.javascript.build.aurelia/webpack.config.js');
+const config = require('@dolittle/build.aurelia/webpack.config.js');
 config.entry = {
     app: ['babel-polyfill', 'aurelia-bootstrapper'],
     vendor: ['bluebird']


### PR DESCRIPTION
The build packages were being referenced directly to their repositories. Updated to use the @dolittle versioned packages.

Using the latest v1 version, as this is compatible with the projects using the module. Is this correct @einari?



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1115618433409986)
