### PR TITLE
Catch errors that are thrown from within the handle-promise

### DIFF
--- a/Source/commands/CommandCustomAttribute.js
+++ b/Source/commands/CommandCustomAttribute.js
@@ -32,13 +32,18 @@ export class CommandCustomAttribute {
             try {
                 if (!this.command && this.value) this.command = this.value;
                 if (typeof this.before == "function") this.before(this.command);
-                this._commandCoordinator.handle(this.command).then(commandResult => {
-                    if (commandResult.success) {
-                        if (typeof this.success == "function") this.success(commandResult);
-                    } else {
-                        if (typeof this.failed == "function") this.failed(commandResult);
-                    }
-                });
+                this._commandCoordinator
+                    .handle(this.command)
+                    .then(commandResult => {
+                        if (commandResult.success) {
+                            if (typeof this.success == "function") this.success(commandResult);
+                        } else {
+                            if (typeof this.failed == "function") this.failed(commandResult);
+                        }
+                    })
+                    .catch(error => {
+                        if( typeof this.error == "function" ) this.error(error);
+                    });
             } catch (ex) {
                 if( typeof this.error == "function" ) this.error(ex);
             }

--- a/Source/commands/for_CommandCustomAttribute/when_command_coordinator_promise_throws_exception_with_error_callback.js
+++ b/Source/commands/for_CommandCustomAttribute/when_command_coordinator_promise_throws_exception_with_error_callback.js
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Dolittle. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { a_command_custom_attribute } from './given/a_command_custom_attribute';
+
+describe('when command coordinator promise throws exception with error callback', () => {
+  let context = new a_command_custom_attribute();
+  const exception = 'something went wrong';
+
+  beforeEach(done => {
+    context.commandCoordinator.handle = command => {
+      return new Promise((resolve, reject) => {
+        throw exception;
+      })
+    };
+
+    context.commandResult.success = true;
+    context.attribute.error = sinon.stub();
+    context.element.onclick();
+    setTimeout(function() {
+      done();
+    }, 1000);
+  });
+
+  it('should call error callback with exception', () => context.attribute.error.calledWith(exception).should.be.true);
+});


### PR DESCRIPTION
This resolves #5. Where exceptions that are being thrown from promises are swallowed.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1121738016578573)
